### PR TITLE
Add support for postgres 9.5

### DIFF
--- a/9.5-1.4/Dockerfile
+++ b/9.5-1.4/Dockerfile
@@ -1,0 +1,12 @@
+FROM postgres:9.5
+MAINTAINER Chia-liang Kao <clkao@clkao.org>
+
+RUN apt-get update \
+	&& apt-get install -y build-essential libv8-dev git-core postgresql-server-dev-$PG_MAJOR \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV PLV8_BRANCH r1.4
+
+RUN cd /tmp && git clone -b $PLV8_BRANCH https://github.com/plv8/plv8.git \
+  && cd /tmp/plv8 \
+  && make all install

--- a/9.5-1.4/README
+++ b/9.5-1.4/README
@@ -1,6 +1,6 @@
 # postgres-plv8
 
-Docker image for running plv8 1.4.x on Postgres 9.4.
+Docker image for running plv8 1.4.x on Postgres 9.5.
 
 Based on the [official Postgres image](http://registry.hub.docker.com/_/postgres/).
 
@@ -9,11 +9,11 @@ Based on the [official Postgres image](http://registry.hub.docker.com/_/postgres
 Start a postgres server container with persistent storage and give it a name:
 
 ```bash
-$ docker run -d -v /tmp/data:/var/lib/postgresql/data --name some-postgres clkao/postgres-plv8:9.4
+$ docker run -d -v /tmp/data:/var/lib/postgresql/data --name some-postgres clkao/postgres-plv8:9.5
 ```
 
 Start client container that links to the server container above as the "postgres" alias:
 
 ```
-$ docker run --link some-postgres:postgres --rm -ti clkao/postgres-plv8:9.4 bash -c 'psql -U postgres -h $POSTGRES_PORT_5432_TCP_ADDR'
+$ docker run --link some-postgres:postgres --rm -ti clkao/postgres-plv8:9.5 bash -c 'psql -U postgres -h $POSTGRES_PORT_5432_TCP_ADDR'
 ```


### PR DESCRIPTION
A note on plv8 1.5.x:

plv8 1.5.x requires a newer version of V8 (4.3.66) which hasn't been made compatible with the `libv8-dev` Debian package yet. The last version available is 3.14.5, launched more than 3 years ago. Statically linking V8 by compiling with `make static` might be the only option going forward. 
