### PR TITLE
Add support for plv8 2.x

### DIFF
--- a/9.4-2.0/Dockerfile
+++ b/9.4-2.0/Dockerfile
@@ -1,0 +1,28 @@
+FROM postgres:9.4
+
+MAINTAINER Chia-liang Kao <clkao@clkao.org>
+
+ENV PLV8_VERSION=4e500549add4b0a84c496f604857c99b2ce0ab5b \
+    PLV8_SHASUM="884281cceee2821098bdc6bd1dff55aea4e3a9845590debae8fba2579a597771  4e500549add4b0a84c496f604857c99b2ce0ab5b.tar.gz"
+
+RUN buildDependencies="build-essential \
+    ca-certificates \
+    curl \
+    git-core \
+    postgresql-server-dev-$PG_MAJOR" \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends ${buildDependencies} \
+  && mkdir -p /tmp/build \
+  && curl -o /tmp/build/${PLV8_VERSION}.tar.gz -SL "https://github.com/plv8/plv8/archive/$PLV8_VERSION.tar.gz" \
+  && cd /tmp/build \
+  && echo ${PLV8_SHASUM} | sha256sum -c \
+  && tar -xzf /tmp/build/${PLV8_VERSION}.tar.gz -C /tmp/build/ \
+  && cd /tmp/build/plv8-${PLV8_VERSION} \
+  && make static \
+  && make install \
+  && strip /usr/lib/postgresql/${PG_MAJOR}/lib/plv8.so \
+  && cd / \
+  && apt-get clean \
+  && apt-get remove -y  ${buildDependencies} \
+  && apt-get autoremove -y \
+  && rm -rf /tmp/build /var/lib/apt/lists/*

--- a/9.5-2.0/Dockerfile
+++ b/9.5-2.0/Dockerfile
@@ -1,0 +1,28 @@
+FROM postgres:9.5
+
+MAINTAINER Chia-liang Kao <clkao@clkao.org>
+
+ENV PLV8_VERSION=4e500549add4b0a84c496f604857c99b2ce0ab5b \
+    PLV8_SHASUM="884281cceee2821098bdc6bd1dff55aea4e3a9845590debae8fba2579a597771  4e500549add4b0a84c496f604857c99b2ce0ab5b.tar.gz"
+
+RUN buildDependencies="build-essential \
+    ca-certificates \
+    curl \
+    git-core \
+    postgresql-server-dev-$PG_MAJOR" \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends ${buildDependencies} \
+  && mkdir -p /tmp/build \
+  && curl -o /tmp/build/${PLV8_VERSION}.tar.gz -SL "https://github.com/plv8/plv8/archive/$PLV8_VERSION.tar.gz" \
+  && cd /tmp/build \
+  && echo ${PLV8_SHASUM} | sha256sum -c \
+  && tar -xzf /tmp/build/${PLV8_VERSION}.tar.gz -C /tmp/build/ \
+  && cd /tmp/build/plv8-${PLV8_VERSION} \
+  && make static \
+  && make install \
+  && strip /usr/lib/postgresql/${PG_MAJOR}/lib/plv8.so \
+  && cd / \
+  && apt-get clean \
+  && apt-get remove -y  ${buildDependencies} \
+  && apt-get autoremove -y \
+  && rm -rf /tmp/build /var/lib/apt/lists/*

--- a/9.6-2.0/Dockerfile
+++ b/9.6-2.0/Dockerfile
@@ -1,0 +1,28 @@
+FROM postgres:9.6
+
+MAINTAINER Chia-liang Kao <clkao@clkao.org>
+
+ENV PLV8_VERSION=4e500549add4b0a84c496f604857c99b2ce0ab5b \
+    PLV8_SHASUM="884281cceee2821098bdc6bd1dff55aea4e3a9845590debae8fba2579a597771  4e500549add4b0a84c496f604857c99b2ce0ab5b.tar.gz"
+
+RUN buildDependencies="build-essential \
+    ca-certificates \
+    curl \
+    git-core \
+    postgresql-server-dev-$PG_MAJOR" \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends ${buildDependencies} \
+  && mkdir -p /tmp/build \
+  && curl -o /tmp/build/${PLV8_VERSION}.tar.gz -SL "https://github.com/plv8/plv8/archive/$PLV8_VERSION.tar.gz" \
+  && cd /tmp/build \
+  && echo ${PLV8_SHASUM} | sha256sum -c \
+  && tar -xzf /tmp/build/${PLV8_VERSION}.tar.gz -C /tmp/build/ \
+  && cd /tmp/build/plv8-${PLV8_VERSION} \
+  && make static \
+  && make install \
+  && strip /usr/lib/postgresql/${PG_MAJOR}/lib/plv8.so \
+  && cd / \
+  && apt-get clean \
+  && apt-get remove -y  ${buildDependencies} \
+  && apt-get autoremove -y \
+  && rm -rf /tmp/build /var/lib/apt/lists/*


### PR DESCRIPTION
plv8 1.4.x is now considered legacy, 1.5.x considered stable and 2.x recommended. We should start incentivising the community to use 2.x for newer projects, so making this available as a docker image should help with that.