### PR TITLE
Add support for Postgres 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,14 @@ before_script:
 env:
   - VERSION=9.4-1.4
   - VERSION=9.4-1.5
-  - VERSION=9.4-2.0
+  - VERSION=9.4-2
   - VERSION=9.5-1.4
   - VERSION=9.5-1.5
-  - VERSION=9.5-2.0
+  - VERSION=9.5-2
   - VERSION=9.6-1.4
   - VERSION=9.6-1.5
-  - VERSION=9.6-2.0
+  - VERSION=9.6-2
+  - VERSION=10-2
 
 language: bash
 

--- a/10-2/Dockerfile
+++ b/10-2/Dockerfile
@@ -1,14 +1,15 @@
-FROM postgres:9.6
+FROM postgres:10
 
 MAINTAINER Chia-liang Kao <clkao@clkao.org>
 
-ENV PLV8_VERSION=v2.0.0 \
-    PLV8_SHASUM="a3a630149342c8dd00ed890ca92f5ed0326eb781cc32d740e34ea58453b041f6  v2.0.0.tar.gz"
+ENV PLV8_VERSION=v2.1.0 \
+    PLV8_SHASUM="207d712e919ab666936f42b29ff3eae413736b70745f5bfeb2d0910f0c017a5c  v2.1.0.tar.gz"
 
 RUN buildDependencies="build-essential \
     ca-certificates \
     curl \
     git-core \
+    python \
     postgresql-server-dev-$PG_MAJOR" \
   && apt-get update \
   && apt-get install -y --no-install-recommends ${buildDependencies} \
@@ -18,11 +19,12 @@ RUN buildDependencies="build-essential \
   && echo ${PLV8_SHASUM} | sha256sum -c \
   && tar -xzf /tmp/build/${PLV8_VERSION}.tar.gz -C /tmp/build/ \
   && cd /tmp/build/plv8-${PLV8_VERSION#?} \
+  && sed -i 's/\(depot_tools.git\)/\1; cd depot_tools; git checkout 46541b4996f25b706146148331b9613c8a787e7e; rm -rf .git;/' Makefile.v8 \
   && make static \
   && make install \
   && strip /usr/lib/postgresql/${PG_MAJOR}/lib/plv8.so \
   && cd / \
   && apt-get clean \
-  && apt-get remove -y  ${buildDependencies} \
+  && apt-get remove -y ${buildDependencies} \
   && apt-get autoremove -y \
   && rm -rf /tmp/build /var/lib/apt/lists/*

--- a/9.4-2/Dockerfile
+++ b/9.4-2/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:9.5
+FROM postgres:9.4
 
 MAINTAINER Chia-liang Kao <clkao@clkao.org>
 
-ENV PLV8_VERSION=v2.0.0 \
-    PLV8_SHASUM="a3a630149342c8dd00ed890ca92f5ed0326eb781cc32d740e34ea58453b041f6  v2.0.0.tar.gz"
+ENV PLV8_VERSION=v2.1.0 \
+    PLV8_SHASUM="207d712e919ab666936f42b29ff3eae413736b70745f5bfeb2d0910f0c017a5c  v2.1.0.tar.gz"
 
 RUN buildDependencies="build-essential \
     ca-certificates \

--- a/9.5-2/Dockerfile
+++ b/9.5-2/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:9.4
+FROM postgres:9.5
 
 MAINTAINER Chia-liang Kao <clkao@clkao.org>
 
-ENV PLV8_VERSION=v2.0.0 \
-    PLV8_SHASUM="a3a630149342c8dd00ed890ca92f5ed0326eb781cc32d740e34ea58453b041f6  v2.0.0.tar.gz"
+ENV PLV8_VERSION=v2.1.0 \
+    PLV8_SHASUM="207d712e919ab666936f42b29ff3eae413736b70745f5bfeb2d0910f0c017a5c  v2.1.0.tar.gz"
 
 RUN buildDependencies="build-essential \
     ca-certificates \
@@ -18,11 +18,12 @@ RUN buildDependencies="build-essential \
   && echo ${PLV8_SHASUM} | sha256sum -c \
   && tar -xzf /tmp/build/${PLV8_VERSION}.tar.gz -C /tmp/build/ \
   && cd /tmp/build/plv8-${PLV8_VERSION#?} \
+  && sed -i 's/\(depot_tools.git\)/\1; cd depot_tools; git checkout 46541b4996f25b706146148331b9613c8a787e7e; rm -rf .git;/' Makefile.v8 \
   && make static \
   && make install \
   && strip /usr/lib/postgresql/${PG_MAJOR}/lib/plv8.so \
   && cd / \
   && apt-get clean \
-  && apt-get remove -y  ${buildDependencies} \
+  && apt-get remove -y ${buildDependencies} \
   && apt-get autoremove -y \
   && rm -rf /tmp/build /var/lib/apt/lists/*

--- a/9.6-1.5/Dockerfile
+++ b/9.6-1.5/Dockerfile
@@ -2,8 +2,8 @@ FROM postgres:9.6
 
 MAINTAINER Chia-liang Kao <clkao@clkao.org>
 
-ENV PLV8_VERSION=v1.5.3 \
-    PLV8_SHASUM="fac8052c926c9ece74f655500caeca50552c0c4b4c7081c0c7946e06ed114d1c  v1.5.3.tar.gz"
+ENV PLV8_VERSION=v1.5.7 \
+    PLV8_SHASUM="08f960aed1d23ee80f3634e107dcee22ea0bd2fdef9ed10dc4efa51541304495  v1.5.7.tar.gz"
 
 RUN buildDependencies="build-essential \
     ca-certificates \
@@ -18,11 +18,12 @@ RUN buildDependencies="build-essential \
   && echo ${PLV8_SHASUM} | sha256sum -c \
   && tar -xzf /tmp/build/${PLV8_VERSION}.tar.gz -C /tmp/build/ \
   && cd /tmp/build/plv8-${PLV8_VERSION#?} \
+  && sed -i 's/\(depot_tools.git\)/\1; cd depot_tools; git checkout d7f5675931137d03f20e1b976bb672d23e109cf0; rm -rf .git;/' Makefile.v8 \
   && make static \
   && make install \
   && strip /usr/lib/postgresql/${PG_MAJOR}/lib/plv8.so \
   && cd / \
   && apt-get clean \
-  && apt-get remove -y  ${buildDependencies} \
+  && apt-get remove -y ${buildDependencies} \
   && apt-get autoremove -y \
   && rm -rf /tmp/build /var/lib/apt/lists/*

--- a/9.6-2/Dockerfile
+++ b/9.6-2/Dockerfile
@@ -1,9 +1,9 @@
-FROM postgres:9.5
+FROM postgres:9.6
 
 MAINTAINER Chia-liang Kao <clkao@clkao.org>
 
-ENV PLV8_VERSION=v1.5.7 \
-    PLV8_SHASUM="08f960aed1d23ee80f3634e107dcee22ea0bd2fdef9ed10dc4efa51541304495  v1.5.7.tar.gz"
+ENV PLV8_VERSION=v2.1.0 \
+    PLV8_SHASUM="207d712e919ab666936f42b29ff3eae413736b70745f5bfeb2d0910f0c017a5c  v2.1.0.tar.gz"
 
 RUN buildDependencies="build-essential \
     ca-certificates \
@@ -18,7 +18,7 @@ RUN buildDependencies="build-essential \
   && echo ${PLV8_SHASUM} | sha256sum -c \
   && tar -xzf /tmp/build/${PLV8_VERSION}.tar.gz -C /tmp/build/ \
   && cd /tmp/build/plv8-${PLV8_VERSION#?} \
-  && sed -i 's/\(depot_tools.git\)/\1; cd depot_tools; git checkout d7f5675931137d03f20e1b976bb672d23e109cf0; rm -rf .git;/' Makefile.v8 \
+  && sed -i 's/\(depot_tools.git\)/\1; cd depot_tools; git checkout 46541b4996f25b706146148331b9613c8a787e7e; rm -rf .git;/' Makefile.v8 \
   && make static \
   && make install \
   && strip /usr/lib/postgresql/${PG_MAJOR}/lib/plv8.so \

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # postgres-plv8
 
-Docker images for running [plv8](https://github.com/plv8/plv8) 1.4, 1.5 and 2.0 on Postgres 9 (9.4, 9.5 and 9.6). Based on the [official Postgres image](http://registry.hub.docker.com/_/postgres/).
+Docker images for running [plv8](https://github.com/plv8/plv8) 1.4, 1.5 and 2.x on Postgres 9 (9.4, 9.5 and 9.6) and 10\. Based on the [official Postgres image](http://registry.hub.docker.com/_/postgres/).
 
-[![clkao/postgres-plv8][docker-pulls-image]][docker-hub-url] [![clkao/postgres-plv8][docker-stars-image]][docker-hub-url]
+[![clkao/postgres-plv8][docker-pulls-image]][docker-hub-url] [![clkao/postgres-plv8][docker-stars-image]][docker-hub-url] [![clkao/postgres-plv8][docker-size-image]][docker-hub-url] [![clkao/postgres-plv8][docker-layers-image]][docker-hub-url]
 
-## Supported tags and respective `Dockerfile` links
-- `9.6-2.0`, `latest` ([9.6-2.0/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/9.6-2.0/Dockerfile))
-- `9.6-1.5` ([9.6-1.5/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/9.6-1.5/Dockerfile))
+## Tags
+
+- `10-2`, `latest` ([9.6-2/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/10-2/Dockerfile))
+- `9.6-2`, ([9.6-2/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/9.6-2/Dockerfile))
 - `9.6-1.4` ([9.6-1.4/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/9.6-1.4/Dockerfile))
-- `9.5-2.0` ([9.5-2.0/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/9.5-2.0/Dockerfile))
+- `9.5-2` ([9.5-1.5/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/9.5-2/Dockerfile))
 - `9.5-1.5` ([9.5-1.5/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/9.5-1.5/Dockerfile))
 - `9.5-1.4` ([9.5-1.4/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/9.5-1.4/Dockerfile))
-- `9.4-2.0` ([9.4-2.0/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/9.4-2.0/Dockerfile))
+- `9.4-2` ([9.4-1.5/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/9.4-2/Dockerfile))
 - `9.4-1.5` ([9.4-1.5/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/9.4-1.5/Dockerfile))
 - `9.4-1.4` ([9.4-1.4/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/9.4-1.4/Dockerfile))
 
@@ -22,8 +23,8 @@ Docker images for running [plv8](https://github.com/plv8/plv8) 1.4, 1.5 and 2.0 
 This image behaves exactly like the official Postgres image with the only difference being the inclusion of the plv8 extension.
 
 ```sh
-$ docker run --rm --name postgres -it clkao/postgres-plv8:9.6-2.0
-$ docker run --rm --link postgres:postgres -it clkao/postgres-plv8:9.6-2.0 bash -c "psql -U postgres -h \$POSTGRES_PORT_5432_TCP_ADDR -t -c \"CREATE EXTENSION plv8; SELECT extversion FROM pg_extension WHERE extname = 'plv8';\""
+$ docker run -d --name postgres clkao/postgres-plv8:10-2
+$ docker exec -it postgres bash -c 'psql -U postgres -c "CREATE EXTENSION plv8; SELECT extversion FROM pg_extension WHERE extname = ''plv8'';"'
 ```
 
 You should see the version of the plv8 extension installed.
@@ -32,7 +33,7 @@ You can optionally create a service using `docker-compose`:
 
 ```yml
 postgres:
-  image: clkao/postgres-plv8:9.6-2.0
+  image: clkao/postgres-plv8:10-2
 ```
 
 ## Image variants
@@ -49,7 +50,7 @@ Points to the latest release available of Postgres `<postgresVersion>` with the 
 
 ## Supported Docker versions
 
-This image is officially supported on Docker version 1.10, with support for older versions provided on a best-effort basis.
+This image is officially supported on Docker version 17.09, with support for older versions provided on a best-effort basis.
 
 ## License
 


### PR DESCRIPTION
Closes https://github.com/clkao/docker-postgres-plv8/pull/28, https://github.com/clkao/docker-postgres-plv8/issues/27 and https://github.com/clkao/docker-postgres-plv8/issues/26.

Regarding #26, depot_tools has to be in sync with the version of V8 being compiled so I checked out a version around the same date.

From version 2.0.0 up, only major versions of plv8 will be tracked. The release cadence under the new maintainer ([@JerrySievert](https://github.com/JerrySievert)) is much higher which makes it both impractical and unnecessary to keep up with dedicated Dockerfile for every minor release.