### PR TITLE
Pinned postgres to 10.4 and pvl8 2.1.2 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   - VERSION=9.6-1.5
   - VERSION=9.6-2
   - VERSION=10-2
+  - VERSION=10.4-2.1.2
 
 language: bash
 

--- a/10.4-2.1.2/Dockerfile
+++ b/10.4-2.1.2/Dockerfile
@@ -1,0 +1,30 @@
+FROM postgres:10.4
+
+MAINTAINER Chia-liang Kao <clkao@clkao.org>
+
+ENV PLV8_VERSION=v2.1.2 \
+    PLV8_SHASUM="47c43feb8f14624f1704616cdc19a2947662a54141cc15568c386f6aac608f23  v2.1.2.tar.gz"
+
+RUN buildDependencies="build-essential \
+    ca-certificates \
+    curl \
+    git-core \
+    python \
+    postgresql-server-dev-$PG_MAJOR" \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends ${buildDependencies} \
+  && mkdir -p /tmp/build \
+  && curl -o /tmp/build/${PLV8_VERSION}.tar.gz -SL "https://github.com/plv8/plv8/archive/$PLV8_VERSION.tar.gz" \
+  && cd /tmp/build \
+  && echo ${PLV8_SHASUM} | sha256sum -c \
+  && tar -xzf /tmp/build/${PLV8_VERSION}.tar.gz -C /tmp/build/ \
+  && cd /tmp/build/plv8-${PLV8_VERSION#?} \
+  && sed -i 's/\(depot_tools.git\)/\1; cd depot_tools; git checkout 46541b4996f25b706146148331b9613c8a787e7e; rm -rf .git;/' Makefile.v8 \
+  && make static \
+  && make install \
+  && strip /usr/lib/postgresql/${PG_MAJOR}/lib/plv8.so \
+  && cd / \
+  && apt-get clean \
+  && apt-get remove -y ${buildDependencies} \
+  && apt-get autoremove -y \
+  && rm -rf /tmp/build /var/lib/apt/lists/*


### PR DESCRIPTION
Pinned postgres to 10.4 and pvl8 2.1.2  to match current amazon rds versions.