### PR TITLE
Add support for Postgres 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ env:
   - VERSION=9.6-1.5
   - VERSION=9.6-2
   - VERSION=10-2
+  - VERSION=11-2
+  - VERSION=12-2
 
 language: bash
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   - VERSION=10-2
   - VERSION=11-2
   - VERSION=12-2
+  - VERSION=13-2
 
 language: bash
 

--- a/13-2/Dockerfile
+++ b/13-2/Dockerfile
@@ -1,0 +1,39 @@
+FROM postgres:13
+
+MAINTAINER Chia-liang Kao <clkao@clkao.org>
+
+ENV PLV8_VERSION=2.3.15 \
+    PLV8_SHASUM="8a05f9d609bb79e47b91ebc03ea63b3f7826fa421a0ee8221ee21581d68cb5ba"
+
+RUN buildDependencies="build-essential \
+    ca-certificates \
+    curl \
+    git-core \
+    python \
+    gpp \
+    cpp \
+    pkg-config \
+    apt-transport-https \
+    cmake \
+    libc++-dev \
+    libc++abi-dev \
+    postgresql-server-dev-$PG_MAJOR" \
+  && runtimeDependencies="libc++1 \
+    libtinfo5 \
+    libc++abi1" \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends ${buildDependencies} ${runtimeDependencies} \
+  && mkdir -p /tmp/build \
+  && curl -o /tmp/build/v$PLV8_VERSION.tar.gz -SL "https://github.com/plv8/plv8/archive/v${PLV8_VERSION}.tar.gz" \
+  && cd /tmp/build \
+  && echo $PLV8_SHASUM v$PLV8_VERSION.tar.gz | sha256sum -c \
+  && tar -xzf /tmp/build/v$PLV8_VERSION.tar.gz -C /tmp/build/ \
+  && cd /tmp/build/plv8-$PLV8_VERSION \
+  && make static \
+  && make install \
+  && strip /usr/lib/postgresql/${PG_MAJOR}/lib/plv8-${PLV8_VERSION}.so \
+  && rm -rf /root/.vpython_cipd_cache /root/.vpython-root \
+  && apt-get clean \
+  && apt-get remove -y ${buildDependencies} \
+  && apt-get autoremove -y \
+  && rm -rf /tmp/build /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # postgres-plv8
 
-Docker images for running [plv8](https://github.com/plv8/plv8) 1.4, 1.5 and 2.x on Postgres 9.4, 9.5, 9.6, 10, 11 and 12. Based on the [official Postgres image](http://registry.hub.docker.com/_/postgres/).
+Docker images for running [plv8](https://github.com/plv8/plv8) 1.4, 1.5 and 2.x on Postgres 9.4, 9.5, 9.6, 10, 11, 12 and 13. 
+Based on the [official Postgres image](http://registry.hub.docker.com/_/postgres/).
 
 [![clkao/postgres-plv8][docker-pulls-image]][docker-hub-url] [![clkao/postgres-plv8][docker-stars-image]][docker-hub-url] [![clkao/postgres-plv8][docker-size-image]][docker-hub-url] [![clkao/postgres-plv8][docker-layers-image]][docker-hub-url]
 
 ## Tags
-
-- `12-2`, `latest` ([12-2/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/12-2/Dockerfile))
+- `13-2`, `latest` ([12-3/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/13-2/Dockerfile))
+- `12` ([12-2/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/12-2/Dockerfile))
 - `11-2` ([11-2/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/11-2/Dockerfile))
 - `10-2` ([10-2/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/10-2/Dockerfile))
 - `9.6-2`, ([9.6-2/Dockerfile](https://github.com/clkao/docker-postgres-plv8/blob/master/9.6-2/Dockerfile))


### PR DESCRIPTION
Using `PLV8_VERSION=2.3.15`

Note: CI will go on failing until PR #40 is merged

The local build `docker build --tag plv8:13-2 . ` failed 
```
plv8.cc: In function ‘void _PG_init()’:
plv8.cc:224:18: error: ‘oid_hash’ was not declared in this scope
```

I hinted at this [issue](https://github.com/plv8/plv8/issues/415#issuecomment-747991453)

The CI build failed even with older versions with `plv8.cc:13:19: error: ‘namespace_’ does not name a type#define namespace namespace_`
I don't know c++, but a similar error popped up in 2016 [here](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=831190)


