### PR TITLE
Bump plv8 version from 2.3.13 to 2.3.15

### DIFF
--- a/12-2/Dockerfile
+++ b/12-2/Dockerfile
@@ -2,8 +2,8 @@ FROM postgres:12
 
 MAINTAINER Chia-liang Kao <clkao@clkao.org>
 
-ENV PLV8_VERSION=2.3.13 \
-    PLV8_SHASUM="1a96c559d98ad757e7494bf7301f0e6b0dd2eec6066ad76ed36cc13fec4f2390"
+ENV PLV8_VERSION=2.3.15 \
+    PLV8_SHASUM="8a05f9d609bb79e47b91ebc03ea63b3f7826fa421a0ee8221ee21581d68cb5ba"
 
 RUN buildDependencies="build-essential \
     ca-certificates \


### PR DESCRIPTION
Issue #36 
Local build ended successfully => have a try on my [DockerHub](https://hub.docker.com/repository/docker/gradedjestrisk/plv8)

```
docker run --detach --env POSTGRES_HOST_AUTH_METHOD=trust --publish 5432:5432 --name postgres_node gradedjestrisk/plv8:12-2
CREATE EXTENSION plv8;
SELECT extversion FROM pg_extension WHERE  AND extname = 'plv8';
-- 2.3.15
```

Look like the CI was already failing before this PR, shall we block the merge and fix it beforehand ?
https://github.com/clkao/docker-postgres-plv8/pull/37#issue-542407890

