### PR TITLE
Allow unauthenticated connexion in CI without failing test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ language: bash
 
 script:
   - docker build -t "${IMAGE}" "${VERSION}"
-  - docker run -d --name postgres "${IMAGE}"
+  - docker run --detach --env POSTGRES_HOST_AUTH_METHOD=trust --name postgres "${IMAGE}"
   - sleep 3
   - while ! docker exec -it postgres pg_isready -U postgres -h 127.0.0.1; do echo "$(date) - waiting for database to start"; sleep 1; done
   - docker exec -it postgres psql -U postgres -c 'CREATE EXTENSION plv8; DO $$ plv8.elog(WARNING, plv8.version) $$ LANGUAGE plv8' | grep "${VERSION#????}"


### PR DESCRIPTION
Previous CI fails because container [was unreachable](https://travis-ci.org/github/GradedJestRisk/docker-postgres-plv8/jobs/751321563)
Look like not setting `POSTGRES_PASSWORD` is the[ root cause](https://github.com/docker-library/postgres/commit/42ce7437ee68150ee29f5272428aa4fc657dc6dc)
As soon as I introduced environment variable `POSTGRES_HOST_AUTH_METHOD`, CI went green