### PR TITLE
Prevent unlimited timeout while connecting to DB in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,7 @@ language: bash
 script:
   - docker build -t "${IMAGE}" "${VERSION}"
   - docker run -d --name postgres "${IMAGE}"
-  - sleep 3
-  - while ! docker exec -it postgres pg_isready -U postgres -h 127.0.0.1; do echo "$(date) - waiting for database to start"; sleep 1; done
+  - docker exec -it postgres pg_isready --timeout=60  -U postgres -h 127.0.0.1;
   - docker exec -it postgres psql -U postgres -c 'CREATE EXTENSION plv8; DO $$ plv8.elog(WARNING, plv8.version) $$ LANGUAGE plv8' | grep "${VERSION#????}"
 
 services: docker


### PR DESCRIPTION
[A previous failing CI](https://travis-ci.org/github/GradedJestRisk/docker-postgres-plv8/builds/750366092) went so far as as 10 hours trying to connect to a stopped container :scream:  :earth_africa: 

The script use `pg_isready`and a infinite loop. 
A [pg_isready](https://www.postgresql.org/docs/current/app-pg-isready.html) option, `timeout` would do the job nicely. I set the timeout to a minute.

Note: after PR #40 is merged, CI will go green so now is a great time to test this feature :smile: 